### PR TITLE
Add Context and Action Blocks & Inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.3] - 2023-09-19
+
+### Added
+- Add `SlackActionsBlock`
+- Add `SlackContextBlock`
+- Add `SlackInputBlock`
+- Created new `SlackInteractiveElement` as base class for buttons & inputs
+- Add `SlackInputElement` with some types (text, url, email, number)
+
+### Changed
+- `SlackButtonElement` now extends `SlackInteractiveElement`
+- `SlackSectionBlock.accessory` must now be a `SlackInteractiveElement`
+
+### Fixed
+- Fixed default button type to be `undefined` instead of `'default'`
+
 ## [v0.0.2] - 2023-09-28
 
 ### Added

--- a/block/actions.js
+++ b/block/actions.js
@@ -1,0 +1,40 @@
+import { SlackBlock } from './block.js';
+import { SlackInteractiveElement } from '../element/interactive.js';
+import { createFactory } from '../functions.js';
+
+export class SlackActionsBlock extends SlackBlock {
+	#elements = [];
+
+	constructor({ elements = [], id } = {}) {
+		super({ id });
+
+		if (! Array.isArray(elements)) {
+			throw new TypeError('elements must be an array.');
+		} else if (elements.length !== 0) {
+			this.add(...elements);
+		}
+	}
+
+	add(...elements) {
+		const count = this.#elements.push(...elements.filter(el => el instanceof SlackInteractiveElement));
+
+		if (count !== elements.length) {
+			throw new Error('Error adding some elements.');
+		}
+
+		return this;
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			elements: this.#elements,
+		};
+	}
+
+	static get TYPE() {
+		return 'actions';
+	}
+}
+
+export const createSlackActionsBlock = createFactory(SlackActionsBlock);

--- a/block/all.js
+++ b/block/all.js
@@ -2,3 +2,6 @@ export { SlackDividerBlock, createSlackDividerBlock } from './divider.js';
 export { SlackHeaderBlock, createSlackHeaderBlock } from './header.js';
 export { SlackImageBlock, createSlackImageBlock } from './image.js';
 export { SlackSectionBlock, createSlackSectionBlock } from './section.js';
+export { SlackActionsBlock, createSlackActionsBlock } from './actions.js';
+export { SlackContextBlock, createSlackContextBlock } from './context.js';
+export { SlackInputBlock, createSlackInputBlock } from './input.js';

--- a/block/context.js
+++ b/block/context.js
@@ -1,0 +1,39 @@
+import { SlackBlock } from './block.js';
+import { SlackTextElement } from '../element/text.js';
+import { SlackImageBlock } from './image.js';
+import { createFactory } from '../functions.js';
+
+export class SlackContextBlock extends SlackBlock {
+	#elements = [];
+
+	constructor({ elements = [], id } = {}) {
+		super({ id });
+
+		if (! Array.isArray(elements)) {
+			throw new TypeError('elements must be an array.');
+		} else if (elements.length !== 0) {
+			this.add(...elements);
+		}
+	}add(...elements) {
+		const count = this.#elements.push(...elements.filter(el => el instanceof SlackTextElement || el instanceof SlackImageBlock));
+
+		if (count !== elements.length) {
+			throw new Error('Error adding some elements.');
+		}
+
+		return this;
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			elements: this.#elements,
+		};
+	}
+
+	static get TYPE() {
+		return 'context';
+	}
+}
+
+export const createSlackContextBlock = createFactory(SlackContextBlock);

--- a/block/input.js
+++ b/block/input.js
@@ -1,0 +1,100 @@
+import { SlackBlock } from './block.js';
+import { SlackPlainTextElement } from '../element/plain-text.js';
+import { SlackInputElement } from '../element/input/input.js';
+import { createFactory } from '../functions.js';
+
+/**
+ * @see https://api.slack.com/reference/block-kit/blocks#input
+ */
+export class SlackInputBlock extends SlackBlock {
+	#element;
+	#optional;
+	#label;
+	#hint;
+
+	constructor(element, { id, hint, label, optional } = {}) {
+		super({ id });
+
+		this.element = element;
+
+		if (typeof hint !== 'undefined') {
+			this.hint = hint;
+		}
+
+		if (typeof label !== 'undefined') {
+			this.label = label;
+		}
+
+		if (typeof optional !== 'undefined') {
+			this.optional = optional;
+		}
+	}
+
+	get element() {
+		return this.#element;
+	}
+
+	set element(val) {
+		if (val instanceof SlackInputElement) {
+			this.#element = val;
+		} else {
+			throw new TypeError('element must be a SlackInputElement.');
+		}
+	}
+
+	get hint() {
+		return this.#hint;
+	}
+
+	set hint(val) {
+		if (typeof val === 'string') {
+			this.#hint = new SlackPlainTextElement(val);
+		} else if (val instanceof SlackPlainTextElement) {
+			this.#hint = val;
+		} else {
+			throw new TypeError('hint must be a string or SlackPlainText object.');
+		}
+	}
+
+	get label() {
+		return this.#label;
+	}
+
+	set label(val) {
+		if (typeof val === 'string') {
+			this.#label = new SlackPlainTextElement(val);
+		} else if (val instanceof SlackPlainTextElement) {
+			this.#label = val;
+		} else {
+			throw new TypeError('label must be a string or SlackPlainText object.');
+		}
+	}
+
+	get optional() {
+		return this.#optional;
+	}
+
+	set optional(val) {
+		if (typeof val === 'boolean') {
+			this.#optional = val;
+		} else {
+			throw new TypeError('optional must be a boolean.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			element: this.#element,
+			label: this.#label,
+			optional: this.#optional,
+			hint: this.#hint,
+		};
+	}
+
+	static get TYPE() {
+		return 'input';
+	}
+}
+
+export const createSlackInputBlock = createFactory(SlackInputBlock);

--- a/block/section.js
+++ b/block/section.js
@@ -1,5 +1,6 @@
 import { SlackBlock } from './block.js';
 import { SlackElement } from '../element/element.js';
+import { SlackInteractiveElement } from '../element/interactive.js';
 import { SlackTextElement } from '../element/text.js';
 import { SlackPlainTextElement } from '../element/plain-text.js';
 import { createFactory } from '../functions.js';
@@ -30,10 +31,10 @@ export class SlackSectionBlock extends SlackBlock {
 	}
 
 	set accessory(val) {
-		if (val instanceof SlackElement) {
+		if (val instanceof SlackInteractiveElement) {
 			this.#accessory = val;
 		} else {
-			throw new TypeError('Accessory must be a SlackElement.');
+			throw new TypeError('Accessory must be a SlackInteractiveElement.');
 		}
 	}
 

--- a/block/section.js
+++ b/block/section.js
@@ -1,5 +1,4 @@
 import { SlackBlock } from './block.js';
-import { SlackElement } from '../element/element.js';
 import { SlackInteractiveElement } from '../element/interactive.js';
 import { SlackTextElement } from '../element/text.js';
 import { SlackPlainTextElement } from '../element/plain-text.js';

--- a/element/all.js
+++ b/element/all.js
@@ -2,3 +2,10 @@ export { SlackButtonElement, createSlackButtonElement } from './button.js';
 export { SlackMarkdownElement, createSlackMarkdownElement } from './markdown.js';
 export { SlackPlainTextElement, createSlackPlainTextElement } from './plain-text.js';
 export { SLACK_DEFAULT, SLACK_PRIMARY, SLACK_DANGER } from './styles.js';
+
+// Inputs
+export {
+	SlackTextInputElement, createSlackTextInputElement, SlackEmailInputElement,
+	createSlackEmailInputElement, SlackURLInputElement, createSlackURLInputElement,
+	SlackNumberInputElement, createSlackNumberInputElement,
+} from './input/all.js';

--- a/element/button.js
+++ b/element/button.js
@@ -1,14 +1,11 @@
-import { SlackElement } from './element.js';
+import { SlackInteractiveElement } from './interactive.js';
 import { SlackPlainTextElement } from './plain-text.js';
 import { SLACK_DEFAULT, SLACK_PRIMARY, SLACK_DANGER } from './styles.js';
 import { isURL } from '../validation.js';
 import { createFactory } from '../functions.js';
 
-
-
-export class SlackButtonElement extends SlackElement {
+export class SlackButtonElement extends SlackInteractiveElement {
 	#text;
-	#action;
 	#url;
 	#value;
 	#style;
@@ -24,16 +21,12 @@ export class SlackButtonElement extends SlackElement {
 		accessibilityLabel,
 		// confirm,
 	} = {}) {
-		super({ id });
+		super({ id, action });
 
 		this.text = text;
 
 		if (typeof accessibilityLabel !== 'undefined') {
 			this.accessibilityLabel = accessibilityLabel;
-		}
-
-		if (typeof action !== 'undefined') {
-			this.action = action;
 		}
 
 		if (typeof style !== 'undefined') {
@@ -58,18 +51,6 @@ export class SlackButtonElement extends SlackElement {
 			this.#accessibilityLabel = val;
 		} else {
 			throw new TypeError('accessibilityLabel must be a non-empty string.');
-		}
-	}
-
-	get action() {
-		return this.#action;
-	}
-
-	set action(val) {
-		if (typeof val === 'string') {
-			this.#action = val;
-		} else {
-			throw new TypeError('action must be a string.');
 		}
 	}
 
@@ -130,7 +111,6 @@ export class SlackButtonElement extends SlackElement {
 			...super.toJSON(),
 			text: this.#text,
 			style: this.#style,
-			action_id: this.#action,
 			url: this.#url,
 			value: this.#value,
 			accessibility_label: this.#accessibilityLabel,
@@ -142,7 +122,7 @@ export class SlackButtonElement extends SlackElement {
 	}
 
 	static get STYLES() {
-		return [SLACK_DEFAULT, SLACK_PRIMARY, SLACK_DANGER];
+		return [SLACK_PRIMARY, SLACK_DANGER];
 	}
 }
 

--- a/element/input/all.js
+++ b/element/input/all.js
@@ -1,0 +1,4 @@
+export { SlackTextInputElement, createSlackTextInputElement } from './text.js';
+export { SlackEmailInputElement, createSlackEmailInputElement } from './email.js';
+export { SlackURLInputElement, createSlackURLInputElement } from './url.js';
+export { SlackNumberInputElement, createSlackNumberInputElement } from './number.js';

--- a/element/input/email.js
+++ b/element/input/email.js
@@ -1,0 +1,40 @@
+import { SlackInputElement } from './input.js';
+import { createFactory } from '../../functions.js';
+import { isEmail } from '../../validation.js';
+
+export class SlackEmailInputElement extends SlackInputElement {
+	#initialValue;
+
+	constructor({ id, action, autoFocus = false, placeholder, initialValue } = {}) {
+		super({ id, action, autoFocus, placeholder });
+
+		if (typeof initialValue !== 'undefined') {
+			this.initialValue = initialValue.toString();
+		}
+	}
+
+	get initialValue() {
+		return this.#initialValue;
+	}
+
+	set initialValue(val) {
+		if (isEmail(val)) {
+			this.#initialValue = val;
+		} else {
+			throw new TypeError('initialValue must be a non-empty string.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			initial_value: this.#initialValue,
+		};
+	}
+
+	static get TYPE() {
+		return 'email_text_input';
+	}
+}
+
+export const createSlackEmailInputElement = createFactory(SlackEmailInputElement);

--- a/element/input/input.js
+++ b/element/input/input.js
@@ -1,0 +1,53 @@
+import { SlackInteractiveElement } from '../interactive.js';
+import { SlackPlainTextElement } from '../plain-text.js';
+
+export class SlackInputElement extends SlackInteractiveElement {
+	#autoFocus;
+	#placeholder;
+
+	constructor({ id, action, autoFocus = false, placeholder }) {
+		super({ id, action });
+
+		if (typeof autoFocus !== 'undefined') {
+			this.autoFocus = autoFocus;
+		}
+
+		if (typeof placeholder !== 'undefined') {
+			this.placeholder = placeholder;
+		}
+	}
+
+	get autoFocus() {
+		return this.#autoFocus;
+	}
+
+	set autoFocus(val) {
+		if (typeof val !== 'boolean') {
+			throw new TypeError('focus must be a boolean.');
+		} else {
+			this.#autoFocus = val;
+		}
+	}
+
+	get placeholder() {
+		return this.#placeholder;
+	}
+
+	set placeholder(val) {
+		if (typeof val === 'string') {
+			this.#placeholder = new SlackPlainTextElement(val);
+		} else if (val instanceof URL || typeof val === 'number') {
+			this.#placeholder = val.toString();
+		} else {
+			throw new TypeError('Invalid placeholder for input.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			placeholder: this.#placeholder,
+			focus_on_load: this.#autoFocus,
+		};
+	}
+}

--- a/element/input/number.js
+++ b/element/input/number.js
@@ -1,0 +1,99 @@
+import { SlackInputElement } from './input.js';
+import { createFactory } from '../../functions.js';
+
+export class SlackNumberInputElement extends SlackInputElement {
+	#initialValue;
+	#minValue;
+	#maxValue;
+	#decimal = false;
+
+	constructor({ id, action, autoFocus = false, placeholder, initialValue, decimal = false, minValue, maxValue } = {}) {
+		super({ id, action, autoFocus, placeholder });
+		this.decimal = decimal;
+
+		if (typeof minValue !== 'undefined') {
+			this.minValue = minValue;
+		}
+
+		if (typeof maxValue === 'number') {
+			this.maxValue = maxValue;
+		}
+
+		if (typeof initialValue !== 'undefined') {
+			this.initialValue = initialValue;
+		}
+	}
+
+	get decimal() {
+		return this.#decimal;
+	}
+
+	set decimal(val) {
+		if (typeof val === 'boolean') {
+			this.#decimal = val;
+		} else {
+			throw new TypeError('decimal must be a boolean.');
+		}
+	}
+
+	get initialValue() {
+		return this.#initialValue;
+	}
+
+	set initialValue(val) {
+		const minValue = this.#minValue;
+		const maxValue = this.#maxValue;
+
+		if (typeof val !== 'number' || ! Number.isFinite(val)) {
+			throw new TypeError('initialValue must be a valid number.');
+		} else if (! this.#decimal && ! Number.isSafeInteger(val)) {
+			throw new TypeError('Floats/decimals not allowed without `decimal: true`.');
+		} else if (typeof minValue === 'number' && val < minValue) {
+			throw new TypeError(`intialValue must be > ${minValue}`);
+		} else if (typeof maxValue === 'number' && val > maxValue) {
+			throw new TypeError(`initialValue must be  > ${maxValue}`);
+		} else {
+			this.#initialValue = val;
+		}
+	}
+
+	get maxValue() {
+		return this.#maxValue;
+	}
+
+	set maxValue(val) {
+		if (typeof val === 'number' && Number.isFinite(val)) {
+			this.#maxValue = val;
+		} else {
+			throw new TypeError('maxValue must be a number that is finite.');
+		}
+	}
+
+	get minValue() {
+		return this.#minValue;
+	}
+
+	set minValue(val) {
+		if (typeof val === 'number' && Number.isFinite(val)) {
+			this.#minValue = val;
+		} else {
+			throw new TypeError('minValue must be a number that is finite.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			is_decimal_allowed: this.#decimal,
+			max_value: this.#maxValue?.toString(),
+			min_value: this.#minValue?.toString(),
+			initial_value: this.#initialValue?.toString(),
+		};
+	}
+
+	static get TYPE() {
+		return 'number_input';
+	}
+}
+
+export const createSlackNumberInputElement = createFactory(SlackNumberInputElement);

--- a/element/input/text.js
+++ b/element/input/text.js
@@ -1,0 +1,93 @@
+import { SlackInputElement } from './input.js';
+import { createFactory } from '../../functions.js';
+
+export class SlackTextInputElement extends SlackInputElement {
+	#initialValue;
+	#maxLength;
+	#minLength;
+	#multiLine;
+
+	constructor({ id, action, autoFocus = false, placeholder, minLength, maxLength, multiLine, initialValue } = {}) {
+		super({ id, action, autoFocus, placeholder });
+
+		if (typeof initialValue !== 'undefined') {
+			this.initialValue = initialValue.toString();
+		}
+
+		if (typeof maxLength !== 'undefined') {
+			this.maxLength = maxLength;
+		}
+
+		if (typeof minLength !== 'undefined') {
+			this.minLength = minLength;
+		}
+
+		if (typeof multiLine !== 'undefined') {
+			this.multiLine = multiLine;
+		}
+	}
+
+	get initialValue() {
+		return this.#initialValue;
+	}
+
+	set initialValue(val) {
+		if (typeof val === 'string' && val.length !== 0) {
+			this.#initialValue = val;
+		} else {
+			throw new TypeError('initialValue must be a non-empty string.');
+		}
+	}
+
+	get maxLength() {
+		return this.#maxLength;
+	}
+
+	set maxLength(val) {
+		if (! (Number.isSafeInteger(val) && val > 0)) {
+			throw new TypeError('maxLength must be a positive integer.');
+		} else {
+			this.#maxLength = val;
+		}
+	}
+
+	get minLength() {
+		return this.#minLength;
+	}
+
+	set minLength(val) {
+		if (! (Number.isSafeInteger(val) && val > 0)) {
+			throw new TypeError('minLength must be a positive integer.');
+		} else {
+			this.#minLength = val;
+		}
+	}
+
+	get multiLine() {
+		return this.#multiLine;
+	}
+
+	set multiLine(val) {
+		if (typeof val === 'boolean') {
+			this.#multiLine = val;
+		} else {
+			throw new TypeError('multiLine must be a boolean.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			initial_value: this.#initialValue,
+			max_length: this.#maxLength,
+			min_length: this.#minLength,
+			multiline: this.#multiLine,
+		};
+	}
+
+	static get TYPE() {
+		return 'plain_text_input';
+	}
+}
+
+export const createSlackTextInputElement = createFactory(SlackTextInputElement);

--- a/element/input/url.js
+++ b/element/input/url.js
@@ -1,0 +1,40 @@
+import { SlackInputElement } from './input.js';
+import { createFactory } from '../../functions.js';
+import { isURL } from '../../validation.js';
+
+export class SlackURLInputElement extends SlackInputElement {
+	#initialValue;
+
+	constructor({ id, action, autoFocus = false, placeholder, initialValue } = {}) {
+		super({ id, action, autoFocus, placeholder });
+
+		if (typeof initialValue !== 'undefined') {
+			this.initialValue = initialValue.toString();
+		}
+	}
+
+	get initialValue() {
+		return this.#initialValue;
+	}
+
+	set initialValue(val) {
+		if (isURL(val)) {
+			this.#initialValue = val;
+		} else {
+			throw new TypeError('initialValue must be a non-empty string.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			initial_value: this.#initialValue,
+		};
+	}
+
+	static get TYPE() {
+		return 'url_text_input';
+	}
+}
+
+export const createSlackURLInputElement = createFactory(SlackURLInputElement);

--- a/element/interactive.js
+++ b/element/interactive.js
@@ -1,0 +1,32 @@
+import { SlackElement } from './element.js';
+
+export class SlackInteractiveElement extends SlackElement {
+	#action;
+
+	constructor({ id, action } = {}) {
+		super({ id });
+
+		if (typeof action !== 'undefined') {
+			this.action = action;
+		}
+	}
+
+	get action() {
+		return this.#action;
+	}
+
+	set action(val) {
+		if (typeof val === 'string' && val.length !== 0) {
+			this.#action = val;
+		} else {
+			throw new TypeError('action must be a non-empty string.');
+		}
+	}
+
+	toJSON() {
+		return {
+			...super.toJSON(),
+			action_id: this.#action,
+		};
+	}
+}

--- a/element/styles.js
+++ b/element/styles.js
@@ -1,3 +1,3 @@
-export const SLACK_DEFAULT = 'default';
+export const SLACK_DEFAULT = undefined;
 export const SLACK_PRIMARY = 'primary';
 export const SLACK_DANGER = 'danger';

--- a/element/text.js
+++ b/element/text.js
@@ -15,6 +15,10 @@ export class SlackTextElement extends SlackElement {
 	set text(val) {
 		if (typeof val === 'string' && val.length !== 0) {
 			this.#text = val;
+		} else if (typeof val === 'number' || val instanceof URL) {
+			this.#text = val.toString();
+		} else if (typeof val === 'boolean') {
+			this.#text = val ? 'true' : 'false';
 		} else {
 			throw new TypeError('text must be a non-empty string.');
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/slack",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/slack",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/slack",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An npm package for sending messages in Slack",
   "type": "module",
   "main": "slack.cjs",

--- a/validation.js
+++ b/validation.js
@@ -12,3 +12,18 @@ export function isURL(val) {
 		}
 	}
 }
+
+export function isEmail(val) {
+	if (typeof val !== 'string' || val.endsWith('/')) {
+		return false;
+	} else {
+		try {
+			const { username, password, host, pathname, search, hash, port } = new URL(`https://${val}/`);
+			return pathname.length === 1 && username.length !== 0 && password.length === 0
+				&& host.length !== 0 && search.length === 0 && hash.length === 0
+				&& port.length === 0;
+		} catch {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
**Added**
- Add `SlackActionsBlock`
- Add `SlackContextBlock`
- Add `SlackInputBlock`
- Created new `SlackInteractiveElement` as base class for buttons &
inputs
- Add `SlackInputElement` with some types (text, url, email, number)

**Changed**
- `SlackButtonElement` now extends `SlackInteractiveElement`
- `SlackSectionBlock.accessory` must now be a `SlackInteractiveElement`

**Fixed**
- Fixed default button type to be `undefined` instead of `'default'`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
